### PR TITLE
Do not initialize ssh-agent twice

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -48,7 +48,7 @@ jobs:
         GIT_SSH_COMMAND: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
       if: github.ref == 'refs/heads/main'
       run: |
-        echo "${{ secrets.GH_PAGES_DEPLOY_KEY }}" | ssh-add
+        echo "${{ secrets.GH_PAGES_DEPLOY_KEY }}" | ssh-add -
 
         tempdir=$(mktemp -d)
 


### PR DESCRIPTION
すみません、 ビルド済み docs を push するときに2回 ssh-agent を初期化することになってしまい、現状 main でエラーが発生しています。

このPRでは、 ssh-agent を2回初期化しないように修正しています。