### PR TITLE
Update m5stack version

### DIFF
--- a/source/assembly/assembly_hard/part_list.rst
+++ b/source/assembly/assembly_hard/part_list.rst
@@ -113,9 +113,9 @@
    6,"製造品","|6|","AKARI Plate",,1,1, ー ,
    7,"購入品","|7|","Lattepanda Alpha","Lattepanda Alpha 864S DFR0546",1,1,"| `秋月電子 <https://akizukidenshi.com/catalog/>`__
    | (M-13736)",
-   8,"購入品","|8|","M5Stack BASIC","M5Stack BASIC v2.6",1,1,"| `秋月電子 <https://akizukidenshi.com/catalog/>`__
+   8,"購入品","|8|","M5Stack BASIC","M5Stack BASIC V2.7",1,1,"| `秋月電子 <https://akizukidenshi.com/catalog/>`__
    | (M-17375)
-   | `スイッチサイエンス <https://www.switch-science.com/products/7362?_pos=2&_sid=2cc3998fb&_ss=r>`__",
+   | `スイッチサイエンス <https://www.switch-science.com/products/9010?_pos=3&_sid=773ec7817&_ss=r>`__",V2.6でも可(秋月電子はV2.6を掲載)
    9,"購入品","|9|","温湿度気圧センサユニット ENVⅢ","M5STACK-U001-C",1,1,"| `秋月電子 <https://akizukidenshi.com/catalog/>`__
    | (M-17213)
    | `スイッチサイエンス <https://www.switch-science.com/products/7254?_pos=2&_sid=9f20b6823&_ss=r>`__",


### PR DESCRIPTION
M5Stack V2.7の動確問題なかったので、リンクを変更しました。
ただし秋月はまだV2.6しか売っていないので、どちらでも可という掲載にしてあります。