### PR TITLE
文言を実際に出てくるBECOME passwordに修正

### DIFF
--- a/source/assembly/setup_soft/setup_ansible.rst
+++ b/source/assembly/setup_soft/setup_ansible.rst
@@ -86,8 +86,8 @@ AKARIのセットアップには、ansibleというセットアップツール�
 
     ./run-ansible.py -i hosts ./system.yml -K --diff -c local
 
-| Default passwordを聞かれます。
-| Default passwordには、それぞれUbuntuのログインパスワードを入力します。
+| BECOME passwordを聞かれます。
+| BECOME passwordには、Ubuntuのログインパスワードを入力します。
 | 初回実行時は時間がかかるので、終了までしばらく待ちます。
 | このセットアップでは、下記の様なタスクが自動で実行されます。
 


### PR DESCRIPTION
実際にターミナルに表示される文言と違ったので修正しました
”それぞれ”という文言も複数入力が必要だった以前の名残だと思うので削除しました