### PR TITLE
Fix path convert

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -14,7 +14,8 @@
 # import sys
 import sphinx_rtd_theme
 # sys.path.insert(0, os.path.abspath('.'))
-
+from sphinx.util import docutils
+from urllib.parse import quote
 
 # -- Project information -----------------------------------------------------
 
@@ -78,6 +79,7 @@ html_static_path = ['_static']
 
 html_style = 'css/akaridoc_theme.css'
 
+docutils.nodes.make_id = quote
 autosummary_generate = True
 autodoc_typehints = 'description'
 autodoc_default_options = {


### PR DESCRIPTION
各小見出しへのパーマリンクが今まで日本語だとうまく作れていませんでした。
(例えば↓のスクショの場合、従来だとリンクの#以降がid1とかになっていた。英語が含まれていると、#以降が英語だけ抽出したリンクになる)
![Screenshot from 2024-11-14 10-45-55](https://github.com/user-attachments/assets/766bb144-38c4-4124-8f4c-36ddc9a4b4d1)

今回の修正で、英語でも日本語でも正しくタイトルを含んだリンクになります。